### PR TITLE
Col type

### DIFF
--- a/R/range_read.R
+++ b/R/range_read.R
@@ -14,7 +14,7 @@
 #' had `sheets_read()`. It still works, but it's deprecated and will go away
 #' rather swiftly.
 #'
-#' @section Column specification:
+#' @section Column Specification:
 #'
 #'   Column types must be specified in a single string of readr-style short
 #'   codes, e.g. "cci?l" means "character, character, integer, guess, logical".
@@ -61,7 +61,7 @@
 #' @param col_types Column types. Either `NULL` to guess all from the
 #'   spreadsheet or a string of readr-style shortcodes, with one character or
 #'   code per column. If exactly one `col_type` is specified, it is recycled.
-#'   See Details for more.
+#'   See Column Specification for more.
 #' @param na Character vector of strings to interpret as missing values. By
 #'   default, blank cells are treated as missing data.
 #' @param trim_ws Logical. Should leading and trailing whitespace be trimmed

--- a/man/range_read.Rd
+++ b/man/range_read.Rd
@@ -61,7 +61,7 @@ entry per unskipped column.}
 \item{col_types}{Column types. Either \code{NULL} to guess all from the
 spreadsheet or a string of readr-style shortcodes, with one character or
 code per column. If exactly one \code{col_type} is specified, it is recycled.
-See Details for more.}
+See Column Specification for more.}
 
 \item{na}{Character vector of strings to interpret as missing values. By
 default, blank cells are treated as missing data.}
@@ -105,7 +105,7 @@ The first release of googlesheets used a \code{sheets_} prefix everywhere, so we
 had \code{sheets_read()}. It still works, but it's deprecated and will go away
 rather swiftly.
 }
-\section{Column specification}{
+\section{Column Specification}{
 
 
 Column types must be specified in a single string of readr-style short

--- a/man/spread_sheet.Rd
+++ b/man/spread_sheet.Rd
@@ -27,7 +27,7 @@ entry per unskipped column.}
 \item{col_types}{Column types. Either \code{NULL} to guess all from the
 spreadsheet or a string of readr-style shortcodes, with one character or
 code per column. If exactly one \code{col_type} is specified, it is recycled.
-See Details for more.}
+See Column Specification for more.}
 
 \item{na}{Character vector of strings to interpret as missing values. By
 default, blank cells are treated as missing data.}

--- a/vignettes/articles/read-sheets.Rmd
+++ b/vignettes/articles/read-sheets.Rmd
@@ -42,9 +42,11 @@ if (identical(Sys.getenv("IN_PKGDOWN"), "true")) Sys.sleep(30)
 ## `read_sheet()` and `range_read()` are synonyms
 
 The main "read" function of the googlesheets4 package goes by two names, because we want it to make sense in two contexts:
+
 * `read_sheet()` evokes other table-reading functions, like
  `readr::read_csv()` and `readxl::read_excel()`. The `sheet` in this case
   refers to a Google (spread)Sheet.
+  
 * `range_read()` is technically the right name according to the naming
   convention used throughout the googlesheets4 package, because we can read from
   an arbitrary cell range.
@@ -57,6 +59,8 @@ rather swiftly.
 ## Specify the range and column types
 
 Here we read from the "mini-gap" and "deaths" example Sheets to show some of the different ways to specify (work)sheet and cell ranges. Note also that `col_types` gives control of column types, similar to how `col_types` works in readr and readxl.
+
+For the full list of column types and how to specify them, see [Column specification](https://googlesheets4.tidyverse.org/reference/range_read.html#column-specification) in the ["Read a Sheet into a data frame" reference](https://googlesheets4.tidyverse.org/reference/range_read.html).  
 
 ```{r}
 range_read(gs4_example("mini-gap"), sheet = 2)

--- a/vignettes/articles/read-sheets.Rmd
+++ b/vignettes/articles/read-sheets.Rmd
@@ -58,9 +58,7 @@ rather swiftly.
 
 ## Specify the range and column types
 
-Here we read from the "mini-gap" and "deaths" example Sheets to show some of the different ways to specify (work)sheet and cell ranges. Note also that `col_types` gives control of column types, similar to how `col_types` works in readr and readxl.
-
-For the full list of column types and how to specify them, see [Column specification](https://googlesheets4.tidyverse.org/reference/range_read.html#column-specification) in the ["Read a Sheet into a data frame" reference](https://googlesheets4.tidyverse.org/reference/range_read.html).  
+Here we read from the "mini-gap" and "deaths" example Sheets to show some of the different ways to specify (work)sheet and cell ranges. 
 
 ```{r}
 range_read(gs4_example("mini-gap"), sheet = 2)
@@ -69,9 +67,21 @@ range_read(gs4_example("mini-gap"), sheet = "Oceania", n_max = 3)
 
 range_read(gs4_example("deaths"), skip = 4, n_max = 10)
 
+```
+
+
+The example below shows the `range` method to specify a sheet ("other") and a cell reference range within that sheet. 
+
+It also demonstrates how `col_types` gives control of column types, similar to how `col_types` works in readr and readxl.
+
+* For the full list of column types and how to specify them, see [Column specification](https://googlesheets4.tidyverse.org/reference/range_read.html#column-specification) in the "Read a Sheet into a data frame" reference.  
+
+```{r}
+
 range_read(
   gs4_example("deaths"), range = "other!A5:F15", col_types = "?ci??D"
 )
+
 ```
 
 If you looked at the "deaths" spreadsheet in the browser (it's [here](https://docs.google.com/spreadsheets/d/1tuYKzSbLukDLe5ymf_ZKdQA8SfOyeMM7rmf6D6NJpxg/edit#gid=1210215306)), you know that it has some of the typical features of real world spreadsheets: the main data rectangle has prose intended for human-consumption before and after it. That's why we have to specify the range when we read from it.

--- a/vignettes/articles/read-sheets.Rmd
+++ b/vignettes/articles/read-sheets.Rmd
@@ -69,12 +69,11 @@ range_read(gs4_example("deaths"), skip = 4, n_max = 10)
 
 ```
 
+The example below shows the use of `range` to specify both the (work)sheet and an A1-style cell range.
 
-The example below shows the `range` method to specify a sheet ("other") and a cell reference range within that sheet. 
+It also demonstrates how `col_types` gives control of column types, similar to how `col_types` works in readr and readxl. Note that currently there is only support for the "shortcode" style of column specification and we plan to align better with readr's capabilities in a future release.
 
-It also demonstrates how `col_types` gives control of column types, similar to how `col_types` works in readr and readxl.
-
-* For the full list of column types and how to specify them, see [Column specification](https://googlesheets4.tidyverse.org/reference/range_read.html#column-specification) in the "Read a Sheet into a data frame" reference.  
+* For the full list of column types and how to specify them, see the [Column specification](https://googlesheets4.tidyverse.org/reference/range_read.html#column-specification) section of the help for `range_read()`.
 
 ```{r}
 


### PR DESCRIPTION
Documentation: 
Add a few points in the "Read a Sheet" and "Read Sheets" to clarify `col_type()` specifications. (Related to https://github.com/tidyverse/googlesheets4/issues/156.)