### PR TITLE
remove mention of `sheets_write` still working

### DIFF
--- a/R/sheet_write.R
+++ b/R/sheet_write.R
@@ -35,8 +35,7 @@
 #'
 #' `write_sheet()` and `sheet_write()` are synonyms and you can use either one.
 #' The first release of googlesheets used a `sheets_` prefix everywhere, so we
-#' had `sheets_write()`. It still works, but it's deprecated and will go away
-#' rather swiftly.
+#' had `sheets_write()`. 
 #'
 #' @param data A data frame. If it has zero rows, we send one empty pseudo-row
 #'   of data, so that we can apply the usual table styling. This empty row goes


### PR DESCRIPTION
In the man page for `sheet_write` there is still mention of `sheets_write` working despite in the version of the current master branch (0.2.0.9000) it isn't exported. 

Checking the full directory:

```bash
grep -rnw '.' -e 'sheets_write'
```
```
./vignettes/articles/function-class-names.Rmd:99:  "`sheets_write()`",            "`sheet_write()`"
./R/sheet_write.R:38:#' had `sheets_write()`. It still works, but it's deprecated and will go away
./man/sheet_write.Rd:65:had \code{sheets_write()}. It still works, but it's deprecated and will go away
```

I've deleted the sentence "It still works, but it's deprecated and will go away" but maybe we should point to the vignette [here](https://googlesheets4.tidyverse.org/articles/articles/function-class-names.html#previous-use-of-sheets_-prefix) or something as well for extra clarity.

Thank you! 