### PR TITLE
Don't init .auth object until .onLoad

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: googlesheets4
 Title: Access Google Sheets using the Sheets API V4
-Version: 0.2.0.9000
+Version: 0.2.0.9001
 Authors@R: 
     c(person(given = "Jennifer",
              family = "Bryan",

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,5 +1,10 @@
 .onLoad <- function(libname, pkgname) {
 
+  .auth <<- gargle::AuthState$new(
+    package     = "googlesheets4",
+    auth_active = TRUE
+  )
+
   if (identical(Sys.getenv("IN_PKGDOWN"), "true") &&
       gargle:::secret_can_decrypt("googlesheets4") &&
       !is.null(curl::nslookup("sheets.googleapis.com", error = FALSE))) {

--- a/R/gs4_auth.R
+++ b/R/gs4_auth.R
@@ -1,10 +1,8 @@
 ## This file is the interface between googlesheets4 and the
 ## auth functionality in gargle.
 
-.auth <- gargle::AuthState$new(
-  package     = "googlesheets4",
-  auth_active = TRUE
-)
+# Initialization happens in .onLoad
+.auth <- NULL
 
 ## The roxygen comments for these functions are mostly generated from data
 ## in this list and template text maintained in gargle.


### PR DESCRIPTION
Creating the .auth object directly at the top-level means the code
from gargle is snapshotted at build time.

This is needed for r-lib/gargle#157, but is a good change even without that PR.