### PR TITLE
Initial  merged cells support in `get_cells()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     rlang (>= 1.0.2),
     tibble (>= 2.1.1),
     utils,
-    vctrs (>= 0.2.3),
+    vctrs (>= 0.4.0),
     withr
 Suggests: 
     covr,


### PR DESCRIPTION
Initial implementation for #289

This adds new columns `n_rows` and `n_cols` to the result of `get_cells()/range_read_cells()`.  API response with the merged cell ranges is parsed in `get_merged_ranges()` and then left-joined by starting location into the cell table.

No updates to documentation, tests, or range formatting yet.  Could also use error handling when implementing the join. 